### PR TITLE
cv_test

### DIFF
--- a/cv_test/CMakeLists.txt
+++ b/cv_test/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.3)
-project(cvTest)
+project(cv_test)
 
 ## Compile as C++11, supported in ROS Kinetic and newer
 # add_compile_options(-std=c++11)
@@ -110,7 +110,7 @@ find_package(OpenCV REQUIRED
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
-#  LIBRARIES cvTest
+#  LIBRARIES cv_test
 #  CATKIN_DEPENDS other_catkin_pkg
 #  DEPENDS system_lib
 )
@@ -126,7 +126,7 @@ include_directories(include ${catkin_INCLUDE_DIRS})
 
 ## Declare a C++ library
 # add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/cvTest.cpp
+#   src/${PROJECT_NAME}/cv_test.cpp
 # )
 
 ## Add cmake target dependencies of the library
@@ -195,7 +195,7 @@ target_link_libraries(${PROJECT_NAME}_node
 #############
 
 ## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_cvTest.cpp)
+# catkin_add_gtest(${PROJECT_NAME}-test test/test_cv_test.cpp)
 # if(TARGET ${PROJECT_NAME}-test)
 #   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 # endif()

--- a/cv_test/package.xml
+++ b/cv_test/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package format="2">
-  <name>cvTest</name>
+  <name>cv_test</name>
   <version>0.0.0</version>
-  <description>The cvTest package</description>
+  <description>The cv_test package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
@@ -19,7 +19,7 @@
   <!-- Url tags are optional, but multiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->
   <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/cvTest</url> -->
+  <!-- <url type="website">http://wiki.ros.org/cv_test</url> -->
 
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->

--- a/cv_test/src/main.cpp
+++ b/cv_test/src/main.cpp
@@ -11,7 +11,7 @@ using namespace cv::cuda;
 
 int main (int argc, char *argv[])
 {
-    ros::init(argc, argv, "cvTest");
+    ros::init(argc, argv, "cv_test");
     ros::NodeHandle n("~");
 
     if (getCudaEnabledDeviceCount() == 0)

--- a/vision_opencv/package.xml
+++ b/vision_opencv/package.xml
@@ -15,6 +15,7 @@
   
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_geometry</run_depend>
+  <run_depend>cv_test</run_depend>
   <export>
     <metapackage/>
   </export>


### PR DESCRIPTION
1: changed cvTest folder to cv_test in order to eliminate naming convention warning when compiling.
2: added cv_test to the vision_opencv metapackage so that the cv_test_node is discoverable from the catkin_ws.

Thx for the repo!